### PR TITLE
Fix dead link in home page

### DIFF
--- a/codewithrockstar.com/index.html
+++ b/codewithrockstar.com/index.html
@@ -43,7 +43,7 @@ Scream "Let's rock! 🤘🏽"</code></pre>
 			<section>
 				<div>
 					<h3><i class="fa-solid fa-download"></i> I Want It All</h3>
-					<p>You can run Rockstar <a href="/try">right here on the web</a>, or you can download a Rockstar
+					<p>You can run Rockstar <a href="/online">right here on the web</a>, or you can download a Rockstar
 						interpreter for Windows, Linux and macOS.</p>
 				</div>
 				<p><i class="fa-solid fa-arrow-right-long"></i> <a href="https://github.com/RockstarLang/rockstar2/releases">Download Rockstar</a></p>


### PR DESCRIPTION
In the home page there is a dead link that points to `/try`, i think you wanted to point to `/online`.